### PR TITLE
Fixed compilation problems with python3 (CMSSW release 12_3_1)

### DIFF
--- a/python/copyEfficiencies.py
+++ b/python/copyEfficiencies.py
@@ -15,7 +15,7 @@ year2017 = False
 year2018 = False
 year2016 = True
 
-print "Making initial SF file"
+print("Making initial SF file")
 
 if(year2017):
 	iFile = ROOT.TFile( '/afs/cern.ch/user/h/hsert/public/Fall17Samples_31MarData_12AprMC/tauTriggerEfficiencies2017_final_perDM_v3.root', 'r' )
@@ -39,12 +39,12 @@ for trigger in ['ditau', 'mutau', 'etau'] :
                 iName2017 = trigger+'_XXX_'+dm+'_'+wp+'TauMVA_'+sample
                 iName2018 = trigger+'_XXX_'+wp+'TauMVA_'+dm+'_'+sample
                 iNameSF = trigger+'_XXX_'+wp+'TauMVA_'+dm
-                print iName2018
+                print(iName2018)
                 if(year2017): iName = iName2017
                 elif(year2018 or year2016): iName = iName2018
                 saveName = trigger+'_'+wp+'MVAv2_'+dm+'_'+sample
                 saveNameSF = trigger+'_'+wp+'MVAv2_'+dm
-                print saveName
+                print(saveName)
                 g = getGraph( iFile, iName.replace('XXX','gEffiFit'), saveName+'_graph' )
                 #hFit = getHist( iFile, iName.replace('XXX','hEffiFit'), saveName+'_Fithisto' )
                 #hCoarse = getHist( iFile, iName.replace('XXX','hEffiCoarse'), saveName+'_CoarseBinhisto' )

--- a/python/getTauTriggerSFs.py
+++ b/python/getTauTriggerSFs.py
@@ -32,7 +32,7 @@ class getTauTriggerSFs :
         assert( (self.wpType == 'MVAv2' and not self.provide_emb_sfs)
                 or (self.wpType == 'DeepTau' and self.provide_emb_sfs) ), "Tau POG is currently only providing MC efficiencies for MVAv2 and embedded efficiencies for DeepTau, sorry."
         assert( self.year in [2016, 2017, 2018] ), "Choose which year trigger efficiencies you need."
-        print "Loading Efficiencies for trigger %s usingTau %s ID WP %s for year %i based on %s samples" % (self.trigger, self.wpType, self.tauWP, self.year, "embedded" if self.provide_emb_sfs else "simulated")
+        print("Loading Efficiencies for trigger %s usingTau %s ID WP %s for year %i based on %s samples" % (self.trigger, self.wpType, self.tauWP, self.year, "embedded" if self.provide_emb_sfs else "simulated"))
 
         # Assume this is in CMSSW with the below path structure
         if file_name is None:
@@ -134,8 +134,8 @@ class getTauTriggerSFs :
         etaPhiVal = etaPhiHist.GetBinContent( etaPhiHist.FindBin( eta, phi ) )
         etaPhiAvg = etaPhiAvgHist.GetBinContent( etaPhiAvgHist.FindBin( eta, phi ) )
         if etaPhiAvg <= 0.0 :
-            print "One of the provided tau (eta, phi) values (%3.3f, %3.3f) is outside the boundary of triggering taus" % (eta, phi)
-            print "Returning efficiency = 0.0"
+            print("One of the provided tau (eta, phi) values (%3.3f, %3.3f) is outside the boundary of triggering taus" % (eta, phi))
+            print("Returning efficiency = 0.0")
             return 0.0
 
         eff *= etaPhiVal / etaPhiAvg
@@ -203,9 +203,9 @@ class getTauTriggerSFs :
         effData = self.getTriggerEfficiencyData( pt, eta, phi, dm )
         effMC = self.getTriggerEfficiencyMC( pt, eta, phi, dm )
         if effMC < 1e-5 :
-            print "Eff MC is suspiciously low. Please contact Tau POG."
-            print " - %s Trigger SF for Tau ID: %s   WP: %s   pT: %f   eta: %s   phi: %f" % (self.trigger, self.wpType, self.tauWP, pt, eta, phi)
-            print " - MC Efficiency = %f" % effMC
+            print("Eff MC is suspiciously low. Please contact Tau POG.")
+            print(" - %s Trigger SF for Tau ID: %s   WP: %s   pT: %f   eta: %s   phi: %f" % (self.trigger, self.wpType, self.tauWP, pt, eta, phi))
+            print(" - MC Efficiency = %f" % effMC)
             return 0.0
 
         if(self.year == 2016):
@@ -216,7 +216,7 @@ class getTauTriggerSFs :
                 if(effMC!=0): sf = effData / effMC
                 else:
                     sf = 0
-                    print "The efficiency is zero in either Data or MC histogram, so SF is set to zero"
+                    print("The efficiency is zero in either Data or MC histogram, so SF is set to zero")
             else:
                 sf = self.getBinnedScaleFactor(pt, dm, self.binnedSFMap[ dm])
 
@@ -224,7 +224,7 @@ class getTauTriggerSFs :
             if(effData!=0 and effMC!=0): sf = effData / effMC
             else:
                 sf = 0
-                print "The efficiency is zero in either Data or MC histogram, so SF is set to zero"
+                print("The efficiency is zero in either Data or MC histogram, so SF is set to zero")
 
         return sf
 

--- a/python/makeEtaPhiFiles.py
+++ b/python/makeEtaPhiFiles.py
@@ -17,10 +17,10 @@ year2016 = True
 # "PixelProblemBarrel" : 0.3589
 
 def fillH2( trigger, wp, dm, sample, info_map, h2 ) :
-    print "Filling: ",h2
+    print("Filling: ", h2)
     for x in range( 1, h2.GetXaxis().GetNbins()+1 ) :
         for y in range( 1, h2.GetYaxis().GetNbins()+1 ) :
-            #print x,y
+            #print(x, y)
             if x == 1 or x == 6 : # beyond eta range, abs(eta)>2.1
                 h2.SetBinContent( x, y, 0.0 )
             elif x == 2 or x == 5 : # end cap, 1.5<abs(eta)<2.1
@@ -30,13 +30,13 @@ def fillH2( trigger, wp, dm, sample, info_map, h2 ) :
             elif x == 4 and y == 2 : # barrel pixel probel region
                 h2.SetBinContent( x, y, info_map[ trigger ][ sample ][ wp ][ dm ][ "PixelProblemBarrel" ] )
             else :
-                print "Didn't we cover all the values?",x,y
+                print("Didn't we cover all the values?", x, y)
 
 def fillH2_2018( trigger, wp, dm, sample, info_map, h2 ) :
-    print "Filling: ",h2
+    print("Filling: ", h2)
     for x in range( 1, h2.GetXaxis().GetNbins()+1 ) :
         for y in range( 1, h2.GetYaxis().GetNbins()+1 ) :
-            #print x,y
+            #print(x, y)
             if x == 1 or x == 6 : # beyond eta range, abs(eta)>2.1
                 h2.SetBinContent( x, y, 0.0 )
             elif x == 2  and y == 2 : # end cap, broken HCAL modules region, 1.5< eta <2.1 and -1.6 < phi< -0.8
@@ -46,10 +46,10 @@ def fillH2_2018( trigger, wp, dm, sample, info_map, h2 ) :
             elif x == 3 or x == 4 : # barrel
                 h2.SetBinContent( x, y, info_map[ trigger ][ sample ][ wp ][ dm ][ "Barrel" ] )
             else :
-                print "Didn't we cover all the values?",x,y
+                print("Didn't we cover all the values?", x, y)
 
 def fillH2_2016( trigger, wp, dm, sample, info_map, h2 ) :
-    print "Filling: ",h2
+    print("Filling: ", h2)
     for x in range( 1, h2.GetXaxis().GetNbins()+1 ) :
         for y in range( 1, h2.GetYaxis().GetNbins()+1 ) :
             if x == 1 or x == 3 : # beyond eta range, abs(eta)>2.1
@@ -57,20 +57,20 @@ def fillH2_2016( trigger, wp, dm, sample, info_map, h2 ) :
             elif x == 2 : # the rest of the eta phi region, no eta phi separation applied for 2016
                 h2.SetBinContent( x, y, info_map[ trigger ][ sample ][ wp ][ dm ][ "Average" ] )
             else :
-                print "Didn't we cover all the values?",x,y
+                print("Didn't we cover all the values?", x, y)
 
         
 def fillAvgH2( trigger, wp, dm, sample, info_map, h2 ) :
-    print "Filling: ",h2
+    print("Filling: ", h2)
     for x in range( 1, h2.GetXaxis().GetNbins()+1 ) :
         for y in range( 1, h2.GetYaxis().GetNbins()+1 ) :
-            #print x,y
+            #print(x, y)
             if x == 1 or x == 3 : # beyond eta range, abs(eta)>2.1
                 h2.SetBinContent( x, y, 0.0 )
             elif x == 2 : # abs(eta)<2.1
                 h2.SetBinContent( x, y, info_map[ trigger ][ sample ][ wp ][ dm ][ "Average" ] )
             else :
-                print "Didn't we cover all the values?",x,y
+                print("Didn't we cover all the values?", x, y)
 
 
 if(year2017):
@@ -84,7 +84,7 @@ elif(year2016):
                 info_map = json.load( etaPhiInfo )
 
 
-print "Making Eta Phi Map"
+print("Making Eta Phi Map")
 #saveDir = '/afs/cern.ch/user/t/truggles/www/tau_fits_Feb13v2/'
 #c = ROOT.TCanvas( 'c1', 'c1', 600, 600 ) 
 #p = ROOT.TPad( 'p1', 'p1', 0, 0, 1, 1 )
@@ -117,7 +117,7 @@ yBinningAvg = array('f', [-3.2, 3.2] )
 for trigger in ['ditau', 'etau', 'mutau'] :
     for wp in ['vvloose', 'vloose', 'loose', 'medium', 'tight', 'vtight', 'vvtight' ] :
         for dm in ['dm0', 'dm1', 'dm10', 'dmCmb'] :
-            print trigger, wp, dm
+            print(trigger, wp, dm)
             h_data = ROOT.TH2F( '%s_%sMVAv2_%s_DATA' % (trigger, wp, dm), '%s_%sMVAv2_%s_DATA;#tau #eta;#tau #phi;Efficiency' % (trigger, wp, dm), len(xBinning)-1, xBinning, len(yBinning)-1, yBinning) 
             h_mc = ROOT.TH2F( '%s_%sMVAv2_%s_MC' % (trigger, wp, dm), '%s_%sMVAv2_%s_MC;#tau #eta;#tau #phi;Efficiency' % (trigger, wp, dm), len(xBinning)-1, xBinning, len(yBinning)-1, yBinning) 
 

--- a/python/makeEtaPhiJson.py
+++ b/python/makeEtaPhiJson.py
@@ -35,18 +35,18 @@ def get_hist_2d( name, tree, cut, weight, x_var, y_var, xBinning, yBinning ) :
     return h
 
 def printJson( to_dump ) :
-	if(year2017):
-            with open('data/tauTriggerEfficienciesEtaPhiMap2017_FINAL.json', 'w') as outFile :
-                json.dump( to_dump, outFile, indent=2 )
-                outFile.close()
-        elif(year2018):
-            with open('data/tauTriggerEfficienciesEtaPhiMap2018_pre.json', 'w') as outFile :
-                json.dump( to_dump, outFile, indent=2 )
-                outFile.close()
-        elif(year2016):
-            with open('data/tauTriggerEfficienciesEtaPhiMap2016_pre.json', 'w') as outFile :
-                json.dump( to_dump, outFile, indent=2 )
-                outFile.close()
+    if(year2017):
+        with open('data/tauTriggerEfficienciesEtaPhiMap2017_FINAL.json', 'w') as outFile :
+            json.dump( to_dump, outFile, indent=2 )
+            outFile.close()
+    elif(year2018):
+        with open('data/tauTriggerEfficienciesEtaPhiMap2018_pre.json', 'w') as outFile :
+            json.dump( to_dump, outFile, indent=2 )
+            outFile.close()
+    elif(year2016):
+        with open('data/tauTriggerEfficienciesEtaPhiMap2016_pre.json', 'w') as outFile :
+            json.dump( to_dump, outFile, indent=2 )
+            outFile.close()
 
 def get_2017trigger_map() :
 
@@ -217,7 +217,7 @@ for trigger in trigger_map.keys() :
         all_info[ trigger ][ sample ] = {}
 
         f = ROOT.TFile( trigger_map[ trigger ][ sample ], 'r' )
-        print trigger, sample, f
+        print(trigger, sample, f)
         t = f.Get("TagAndProbe")
 
         for wp, wp_long in wp_map.iteritems() :


### PR DESCRIPTION
Hi,

this PR contains a few fixes that makes the python scripts compile in CMSSW_12_3_1 (python3).
The PR contains two types of changes:
1) adding parentheses around print statements
2) fixed indentation (replacing tabs by spaces)

Both types of changes should be fully backwards compatible to older CMSSW releases (python2). 

Please merge this PR (so other people using CMSSW_12_3_1/python3 can benefit from these changes)

Thank you,


Christian